### PR TITLE
Fix footer: Hivr -> Hivr.Online

### DIFF
--- a/index.html
+++ b/index.html
@@ -7153,7 +7153,7 @@
  <div class="text-center md:text-left">
  <p class="font-semibold text-nord-sym-text-light mb-2" style="color: #ffffff;">Products</p>
  <div class="footer-quicklinks">
- <a href="https://hivr.online" target="_blank" rel="noopener noreferrer" class="footer-link">🐝 Hivr</a>
+ <a href="https://hivr.online" target="_blank" rel="noopener noreferrer" class="footer-link">🐝 Hivr.Online</a>
  <a href="https://apiclaw.cloud" target="_blank" rel="noopener noreferrer" class="footer-link">🦞 APIClaw</a>
  <a href="https://aisearch.nordsym.com" target="_blank" rel="noopener noreferrer" class="footer-link">🔍 AEO Audit</a>
  <a href="https://genprd.se" target="_blank" rel="noopener noreferrer" class="footer-link">📄 GenPRD</a>


### PR DESCRIPTION
Footer product link label updated from "Hivr" to "Hivr.Online" for consistency with hivrTitle in lang.js and the Skeppa.nu treatment.

https://claude.ai/code/session_01RJhtrgVXsmk5ku7GqZAJjt